### PR TITLE
Fix css clean up#121

### DIFF
--- a/db/products.js
+++ b/db/products.js
@@ -53,7 +53,7 @@ const createProduct = async ({
   }
 };
 
-const destroyProduct = ({id}) => {
+const destroyProduct = async ({id}) => {
   try {
     const { rows: [products] } = await client.query(`
     DELETE FROM order_products

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,3 +1,7 @@
 #root .navbar {
   padding-bottom: 3.5rem;
 }
+
+/* .bodyWrapper {
+  background-color: blue;
+} */

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -3,6 +3,7 @@ import { Card, ListGroupItem, ListGroup, Button, Nav } from "react-bootstrap";
 import { getOrdersByUserId } from '../api';
 import { useParams } from "react-router-dom";
 import "./Account.css"
+import "./index.css";
 
 // export function UserInfo(props) {
 //     const { user } = props;
@@ -29,6 +30,7 @@ const Account = (props) => {
     }, [orders, user, token])
     return (
         <>
+        <div className="bodyWrapper">
             <div className="dash-board">
                 <Card style={{ width: '18rem' }}>
                     {/* <Card.Img variant="top" src="holder.js/100px180?text=Image cap" /> */}
@@ -61,6 +63,7 @@ const Account = (props) => {
                     )
                 })}
             </div>
+         </div>
         </>
     );
 };

--- a/src/components/Cart.js
+++ b/src/components/Cart.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { SingleOrder } from "./"
+import "./index.css";
 // import { useParams } from "react-router-dom";
 
 
@@ -20,6 +21,7 @@ const Cart = (props) => {
 
 
   return ( <>
+  <div className="bodyWrapper">
   <h1> Shopping Cart </h1>
     {/* <h5> Welcome {user.firstName} {user.lastName}</h5> */}
     <p> Ready to checkout? With our stripe integration you can checkout feeling secure.</p>
@@ -57,7 +59,7 @@ const Cart = (props) => {
         </div>
       </div>
 
-
+      </div>
   </>)
 
 }

--- a/src/components/Footer.css
+++ b/src/components/Footer.css
@@ -1,19 +1,10 @@
 #footerdiv {
-  /* position: bottom;
+  position: bottom;
   clear: both;
   padding-top: 4rem;
   left: 0;
   bottom: 0;
   width: 100%;
   text-align: center;
-  padding-bottom: 0; */
-
-  /* relative? */
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  /* background-color: red; */
-  color: white;
-  text-align: center;
+  padding-bottom: 0;
 }

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -1,5 +1,7 @@
 import React from 'react'
 import './Home.css'
+import "./index.css";
+
 import {
   Link,
 } from 'react-router-dom'
@@ -7,7 +9,7 @@ import {
 // import { Product } from "./"
 
 const Home = (props) => {
-  return <div>
+  return <div className="bodyWrapper">
     <div className="hero-image">
   <div className="hero-text">
     <h1>Welcome to Virtual Traders</h1>

--- a/src/components/Product.js
+++ b/src/components/Product.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import Card from "react-bootstrap/Card";
 import Button from "react-bootstrap/Button";
 import "./Product.css";
+import "./index.css";
 import {addProductToOrder, removeProductFromOrder, getCartByUser, createOrder} from "../api"
 import { BrowserRouter as Router,
   useParams,
@@ -98,6 +99,7 @@ console.log('222', productId, price, quantity)
 
   return (
     <>
+    <div className="bodyWrapper flexWrapper">
       { products && products.map(({category, description, id, imageURL, quantity, inStock, name, price}) => <>
 
             <Card style={{ width: "18rem" }}>
@@ -108,7 +110,7 @@ console.log('222', productId, price, quantity)
           <Card.Text>{price}</Card.Text>
           <Card.Text>{category}</Card.Text>
           <Card.Text>{inStock}</Card.Text>
-          <Link className="btn btn-primary" to={`/products/${id}`}>View Product2</Link>
+          <Link className="btn btn-primary " to={`/products/${id}`}>View Product2</Link>
 
           <Button className="btn btn-primary" onClick={ (event) => {
             event.preventDefault()
@@ -133,7 +135,7 @@ console.log('222', productId, price, quantity)
 
       </>
       )}
-
+      </div>
     </>
   );
 };

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -4,6 +4,7 @@ import {useHistory} from 'react-router-dom'
 import {InputGroup, Form, FormControl, Button, Alert} from 'react-bootstrap';
 import Modal from 'react-bootstrap/Modal'
 import {register, getUser} from "../api"
+import "./index.css";
 
 import {getLocalToken, setLocalToken} from '../util'
 
@@ -54,6 +55,7 @@ export default props => {
 
   return (
     <>
+    <div className="bodyWrapper">
       {/* <Button variant="primary" onClick={handleShow}>
         Register Modal
       </Button> */}
@@ -151,6 +153,7 @@ export default props => {
         <p className="btn-danger"> {message} </p>
         </Modal.Footer>
       </Modal>
+      </div>
     </>
   );
 

--- a/src/components/SingleOrder.js
+++ b/src/components/SingleOrder.js
@@ -26,7 +26,7 @@ const SingleOrder = (props) => {
 
 
     return ( <>
-        <div className="single-order">
+        <div className="single-order bodyWrapper">
             <div className="products">
             <h1>My Order: </h1>
                 { orders && orders.map(({products, id, userId, datePlaced, status}) =>

--- a/src/components/SingleProduct.js
+++ b/src/components/SingleProduct.js
@@ -3,6 +3,7 @@ import { useParams } from 'react-router-dom';
 import Card from "react-bootstrap/Card";
 import Button from "react-bootstrap/Button";
 import { getProductById } from "../api";
+import "./index.css";
 
 const SingleProduct = () => {
     const [product, setProduct] = useState({});
@@ -12,7 +13,9 @@ const SingleProduct = () => {
         getProductById(productId).then(setProduct);
     }, [])
 
-    return (
+    return ( <>
+    <div className="bodyWrapper">
+
       <Card style={{ width: "18rem" }}>
         <Card.Img variant="top" src={product.imageURL} />
         <Card.Body>
@@ -24,7 +27,8 @@ const SingleProduct = () => {
           <Button variant="primary">Go somewhere</Button>
         </Card.Body>
       </Card>
-    );
+      </div>
+   </> );
 }
 
 export default SingleProduct;

--- a/src/components/index.css
+++ b/src/components/index.css
@@ -1,0 +1,12 @@
+.flexWrapper {
+  display: grid;
+  grid-template-columns: auto auto auto;
+  padding: 10px;
+}
+
+.bodyWrapper {
+  position: relative;
+  /* min-height: 80vh; */
+  padding-top: 3.5rem;
+  min-height: 100vh;
+}


### PR DESCRIPTION
add grid display 3 x 3 for products with no mobile breakpoint. Looks good on desktop.
fixed footer. puts footer on bottom of page.
fixed issue with nav bar overlapping page body content.

Simply wrap any component in bodyWrapper div to each component needing to push the footer to the bottom or pad from top.
